### PR TITLE
AssertJ 의 의존성을 추가한다.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,7 @@ subprojects {
         testImplementation("org.springframework.boot:spring-boot-starter-test") {
             exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
         }
+        testImplementation("org.assertj:assertj-core:3.11.1")
     }
 
     tasks.withType<Test> {
@@ -92,6 +93,7 @@ project(":client:security-configuration") {
 
     dependencies {
         implementation("org.springframework.boot:spring-boot-starter-security")
+        testImplementation("org.springframework.security:spring-security-test")
     }
     val jar: Jar by tasks
     val bootJar: BootJar by tasks


### PR DESCRIPTION
테스트코드의 가독성을 보강해주는 AssertJ 라이브러리를 사용하기 위해
그래들에 subproject에 testImplementation으로 추가해준다.

work items : #2 